### PR TITLE
Technology moratorium and carbon budget plot

### DIFF
--- a/mppshared/config.py
+++ b/mppshared/config.py
@@ -298,16 +298,16 @@ RANKING_CONFIG = {
 # REGIONAL_PRODUCTION_SHARE Ammonia
 REGIONAL_PRODUCTION_SHARES = {
     "chemicals": {
-        "Africa": 0.3,
-        "China": 0.3,
-        "Europe": 0.3,
-        "India": 0.3,
-        "Latin America": 0.3,
-        "Middle East": 0.3,
-        "North America": 0.3,
-        "Oceania": 0.3,
-        "Russia": 0.3,
-        "Rest of Asia": 0.3,
+        "Africa": 0.4,
+        "China": 0.4,
+        "Europe": 0.4,
+        "India": 0.4,
+        "Latin America": 0.4,
+        "Middle East": 0.4,
+        "North America": 0.4,
+        "Oceania": 0.4,
+        "Russia": 0.4,
+        "Rest of Asia": 0.4,
     },
     "aluminium": {
         "China - North": 0.3,
@@ -341,7 +341,7 @@ SECTORAL_CARBON_BUDGETS = {
 }
 
 residual_share = 0.05
-emissions_chemicals_2020 = 0.51  # Gt CO2 (scope 1 and 2)
+emissions_chemicals_2020 = 1  # Gt CO2 (scope 1 and 2)
 
 SECTORAL_PATHWAYS = {
     "chemicals": {
@@ -354,4 +354,10 @@ SECTORAL_PATHWAYS = {
         "emissions_end": residual_share * emissions_chemicals_2020,
         "action_start": 2025,
     },
+}
+
+# Year from which newbuild capacity must have transition or end-state technology
+TECHNOLOGY_MORATORIUM = {   
+    "chemicals": 2020,
+    "aluminium": 2050 # constraint currently not active
 }

--- a/mppshared/models/simulate.py
+++ b/mppshared/models/simulate.py
@@ -56,14 +56,15 @@ def simulate(pathway: SimulationPathway) -> SimulationPathway:
             )
 
             #! Debug: set carbon budget start to initial emissions (needs to be implemented)
-            if year == START_YEAR:
-                emissions = pathway.calculate_emissions_stack(year, product)
-                limit = (emissions["co2_scope1"] + emissions["co2_scope2"]) / 1e3
-                df = pathway.carbon_budget.pathways[pathway.sector]
-                df.loc[START_YEAR, "annual_limit"] = limit
+            # Let's remove this and make sure the annual emissions limit is initalized correctly at the start
+            # if year == START_YEAR:
+            #     emissions = pathway.calculate_emissions_stack(year, product)
+            #     limit = (emissions["co2_scope1"] + emissions["co2_scope2"]) / 1e3
+            #     df = pathway.carbon_budget.pathways[pathway.sector]
+            #     df.loc[START_YEAR, "annual_limit"] = limit
 
             # Decommission assets
-            # pathway = decommission(pathway=pathway, year=year, product=product)
+            pathway = decommission(pathway=pathway, year=year, product=product)
 
             # Renovate and rebuild assets (brownfield transition)
             pathway = brownfield(pathway=pathway, year=year, product=product)
@@ -95,6 +96,7 @@ def simulate_pathway(sector: str, pathway: str, sensitivity: str):
     carbon_budget = CarbonBudget(
         sectoral_carbon_budgets=SECTORAL_CARBON_BUDGETS, pathway_shape="linear"
     )
+    carbon_budget.output_emissions_pathway(sector=sector, importer=importer)
 
     # Make pathway
     pathway = SimulationPathway(

--- a/mppshared/solver/implicit_forcing.py
+++ b/mppshared/solver/implicit_forcing.py
@@ -13,6 +13,7 @@ from mppshared.config import (
     GHGS,
     INITIAL_CARBON_COST,
     PRODUCTS,
+    TECHNOLOGY_MORATORIUM,
 )
 from mppshared.import_data.intermediate_data import IntermediateDataImporter
 from mppshared.models.carbon_cost_trajectory import CarbonCostTrajectory
@@ -54,9 +55,15 @@ def apply_implicit_forcing(pathway: str, sensitivity: str, sector: str) -> pd.Da
 
     # Apply technology availability constraint
     # TODO: eliminate transitions from one end-state technology to another!
-    df = apply_technology_availability_constraint(
+    df_technology_switches = apply_technology_availability_constraint(
         df_technology_switches, df_technology_characteristics
     )
+
+    # Apply technology moratorium (year after which newbuild capacity must be transition or end-state technologies)
+    df_technology_switches = apply_technology_moratorium(
+        df_technology_switches=df_technology_switches, 
+        df_technology_characteristics=df_technology_characteristics,
+        moratorium_year=TECHNOLOGY_MORATORIUM[sector])
 
     carbon_cost = 0
     if carbon_cost == 0:
@@ -77,8 +84,6 @@ def apply_implicit_forcing(pathway: str, sensitivity: str, sector: str) -> pd.Da
     # TODO: add carbon cost to LCOX and other cost metrics
 
     # TODO: Subtract green premium from eligible technologies
-
-    # TODO: Eliminate switches according to technology moratorium
 
     # Calculate emission deltas between origin and destination technology
     df_ranking = calculate_emission_reduction(df_carbon_cost, df_emissions)
@@ -249,6 +254,25 @@ def apply_technology_availability_constraint(
         ]
     )
 
+def apply_technology_moratorium(df_technology_switches: pd.DataFrame, df_technology_characteristics: pd.DataFrame, moratorium_year: int) -> pd.DataFrame:
+    """Eliminate all newbuild transitions to a conventional technology after a specific year"""
+
+    # Add technology classification to each destination technology
+    df_tech_char_destination = df_technology_characteristics[
+        ["product", "year", "region", "technology", "technology_classification"]
+    ].rename(
+        {
+            "technology": "technology_destination"
+        },
+        axis=1,
+    )
+    df_technology_switches = df_technology_switches.merge(df_tech_char_destination, on=["product", "year", "region", "technology_destination"])
+
+    # Drop technology transitions of type new-build where the technology_destination is classified as initial
+    banned_transitions = (df_technology_switches["year"] >= moratorium_year) & (df_technology_switches["technology_classification"]=="initial")
+    df_technology_switches = df_technology_switches.loc[~banned_transitions]
+
+    return df_technology_switches
 
 def calculate_emission_reduction(
     df_technology_switches: pd.DataFrame, df_emissions: pd.DataFrame


### PR DESCRIPTION
Two additions:

- Application of a technology moratorium: year from which newbuild capacity must have a transition or end-state technology
- Automatic plotting and csv export of the annual emissions constraint derived from the carbon budget (includes commenting out of the section that manually sets the 2020 emissions constraint to 2020 emissions, this is no longer needed)
- 
Close #57 